### PR TITLE
Positioner point updates

### DIFF
--- a/descartes_tutorials/CMakeLists.txt
+++ b/descartes_tutorials/CMakeLists.txt
@@ -16,7 +16,23 @@ find_package(catkin REQUIRED COMPONENTS
   descartes_opw_model
 )
 
-catkin_package()
+catkin_package(
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    positioner_point
+  CATKIN_DEPENDS
+    roslib
+    descartes_core
+    descartes_moveit
+    descartes_trajectory
+    descartes_planner
+    descartes_utilities
+    trajectory_msgs
+    tf
+    tf_conversions
+    descartes_opw_model
+)
 
 ###########
 ## Build ##
@@ -25,6 +41,14 @@ catkin_package()
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+)
+
+# Positioner point library
+add_library(positioner_point
+  src/positioner_point.cpp
+)
+target_link_libraries(positioner_point
+  ${catkin_LIBRARIES}
 )
 
 # Tutorial 1

--- a/descartes_tutorials/include/descartes_tutorials/positioner_point.h
+++ b/descartes_tutorials/include/descartes_tutorials/positioner_point.h
@@ -6,7 +6,18 @@
 class PositionerPoint : public descartes_core::TrajectoryPt
 {
 public:
-  PositionerPoint(const Eigen::Affine3d& turn_table, const Eigen::Affine3d& pt, double turn_table_disc, double pt_disc,
+  PositionerPoint(const Eigen::Affine3d& turn_table,
+                  const Eigen::Affine3d& pt,
+                  double turn_table_disc,
+                  double turn_table_sym_tol,
+                  double pt_disc,
+                  double pt_sym_tol,
+                  descartes_core::TimingConstraint timing);
+
+  PositionerPoint(const Eigen::Affine3d& turn_table,
+                  const Eigen::Affine3d& pt,
+                  double turn_table_disc,
+                  double pt_disc,
                   descartes_core::TimingConstraint timing);
 
   // TrajectoryPt interface
@@ -23,7 +34,7 @@ public:
 
 private:
   Eigen::Affine3d turn_table_, pt_;
-  double table_disc_, pt_disc_;
+  double table_disc_, table_sym_tol_, pt_disc_, pt_sym_tol_;
 };
 
 #endif // POSITIONER_POINT_H

--- a/descartes_tutorials/src/positioner_point.cpp
+++ b/descartes_tutorials/src/positioner_point.cpp
@@ -1,7 +1,34 @@
 #include "descartes_tutorials/positioner_point.h"
 
-PositionerPoint::PositionerPoint(const Eigen::Affine3d &turn_table, const Eigen::Affine3d &pt, double turn_table_disc, double pt_disc, descartes_core::TimingConstraint timing)
-  : TrajectoryPt(timing), turn_table_(turn_table), pt_(pt), table_disc_(turn_table_disc), pt_disc_(pt_disc)
+PositionerPoint::PositionerPoint(const Eigen::Affine3d &turn_table,
+                                 const Eigen::Affine3d &pt,
+                                 double turn_table_disc,
+                                 double turn_table_sym_tol,
+                                 double pt_disc,
+                                 double pt_sym_tol,
+                                 descartes_core::TimingConstraint timing)
+  : TrajectoryPt(timing),
+    turn_table_(turn_table),
+    pt_(pt),
+    table_disc_(turn_table_disc),
+    table_sym_tol_(turn_table_sym_tol),
+    pt_disc_(pt_disc),
+    pt_sym_tol_(pt_sym_tol)
+{
+}
+
+PositionerPoint::PositionerPoint(const Eigen::Affine3d &turn_table,
+                                 const Eigen::Affine3d &pt,
+                                 double turn_table_disc,
+                                 double pt_disc,
+                                 descartes_core::TimingConstraint timing)
+  : TrajectoryPt(timing),
+    turn_table_(turn_table),
+    pt_(pt),
+    table_disc_(turn_table_disc),
+    table_sym_tol_(M_PI),
+    pt_disc_(pt_disc),
+    pt_sym_tol_(M_PI)
 {
 }
 
@@ -33,9 +60,9 @@ bool PositionerPoint::getNominalJointPose(const std::vector<double> &seed_state,
 void PositionerPoint::getJointPoses(const descartes_core::RobotModel &model, std::vector<std::vector<double> > &joint_poses) const
 {
   std::vector<std::vector<double>> results;
-  for (double table = -M_PI; table < M_PI; table += table_disc_)
+  for (double table = -table_sym_tol_; table < table_sym_tol_; table += table_disc_)
   {
-    for (double angle = -M_PI; angle < M_PI; angle += 0.25)
+    for (double angle = -pt_sym_tol_; angle < pt_sym_tol_; angle += pt_disc_)
     {
       Eigen::Affine3d pose = turn_table_ * Eigen::AngleAxisd(table, Eigen::Vector3d::UnitZ()) * pt_ * Eigen::AngleAxisd(angle, Eigen::Vector3d::UnitZ());
       model.getAllIK(pose, results);


### PR DESCRIPTION
Just a few updates after using this for the past couple days:
  - Constructor overload to support the specification of symmetric tolerances with which to discretize the positioner and tool DOFs
  - Modified the catkin package to share the library and headers for the positioner points